### PR TITLE
Use new unified back-end repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If this command fails, check out [Troubleshooting](#troubleshooting) for suggest
  5. Set up directory structure. If you have access to the Permanent repositories, navigate to the parent directory of this directory and clone the needed repositories.
 ```
 cd ..
-for r in mdot docker website task-runner library api daemon; do git clone git@bitbucket.org:permanent-org/$r.git; done
+for r in mdot docker website back-end; do git clone git@bitbucket.org:permanent-org/$r.git; done
 for r in infrastructure upload-service; do git clone git@github.com:PermanentOrg/$r.git; done
 mkdir log
 ```
@@ -50,7 +50,7 @@ mkdir log
 No repository access? Simply create the directories.
 ```
 cd ..
-for r in mdot docker website task-runner library api daemon log; do mkdir $r; done
+for r in mdot docker website back-end/task-runner back-end/library back-end/api back-end/daemon log; do mkdir -p $r; done
 for r in infrastructure upload-service; do git clone git@github.com:PermanentOrg/$r.git; done
 ```
 
@@ -64,7 +64,7 @@ printf "\n192.168.33.10 local.permanent.org" | sudo tee -a /etc/hosts
 source .env && vagrant up
 ```
 
-Vagrant will only provision your VM on the first run of `vagrant up`. Every subsequent time, you must pass the `--provision` [flag](https://www.vagrantup.com/docs/cli/up#no-provision) to force a provisioner to run. This may be useful to install changes to the development environment, or wipe stateful data with the `DELETE_DATA` environment variable (see step 4 above). For more information about working with vagrant, check out [the docs](https://www.vagrantup.com/docs). 
+Vagrant will only provision your VM on the first run of `vagrant up`. Every subsequent time, you must pass the `--provision` [flag](https://www.vagrantup.com/docs/cli/up#no-provision) to force a provisioner to run. This may be useful to install changes to the development environment, or wipe stateful data with the `DELETE_DATA` environment variable (see step 4 above). For more information about working with vagrant, check out [the docs](https://www.vagrantup.com/docs).
 
 8. Load the website at https://local.permanent.org/. If you wish to sign up for an account, do that from the form on https://local.permanent.org/app. It's not possible to create an account locally on https://local.permanent.org/login because this form is an iframe pointing to our production instance.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,11 +37,11 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "../api", "/data/www/api", owner: "vagrant", group: "www-data"
+  config.vm.synced_folder "../back-end/api", "/data/www/api", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../docker", "/data/www/docker", owner: "vagrant", group: "www-data"
-  config.vm.synced_folder "../daemon", "/data/www/daemon", owner: "vagrant", group: "www-data"
-  config.vm.synced_folder "../library", "/data/www/library", owner: "vagrant", group: "www-data"
-  config.vm.synced_folder "../task-runner", "/data/www/task-runner", owner: "vagrant", group: "www-data"
+  config.vm.synced_folder "../back-end/daemon", "/data/www/daemon", owner: "vagrant", group: "www-data"
+  config.vm.synced_folder "../back-end/library", "/data/www/library", owner: "vagrant", group: "www-data"
+  config.vm.synced_folder "../back-end/task-runner", "/data/www/task-runner", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../website", "/data/www/website", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../log", "/var/log/permanent", owner: "vagrant", group: "www-data", mount_options: ["dmode=770", "fmode=660"]
   config.vm.synced_folder "../web-app", "/data/www/mdot", owner: "vagrant", group: "www-data"


### PR DESCRIPTION
Use the newly created repo that consolidates the four PHP repos by mapping its subdirectories to their old names.

Developers will need to check out the new repo. The Vagrant machine can get the new mappings by shutting down the instance, and running `vagrant up` again.

PER-8117 Unify PHP repositories