### PR TITLE
Stop building web-app during vagrant provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ If this command fails, check out [Troubleshooting](#troubleshooting) for suggest
  5. Set up directory structure. If you have access to the Permanent repositories, navigate to the parent directory of this directory and clone the needed repositories.
 ```
 cd ..
-for r in mdot docker website back-end; do git clone git@bitbucket.org:permanent-org/$r.git; done
-for r in infrastructure upload-service; do git clone git@github.com:PermanentOrg/$r.git; done
+for r in docker website back-end; do git clone git@bitbucket.org:permanent-org/$r.git; done
+for r in infrastructure upload-service web-app; do git clone git@github.com:PermanentOrg/$r.git; done
 mkdir log
 ```
 
 No repository access? Simply create the directories.
 ```
 cd ..
-for r in mdot docker website back-end/task-runner back-end/library back-end/api back-end/daemon log; do mkdir -p $r; done
+for r in web-app/dist docker website back-end/task-runner back-end/library back-end/api back-end/daemon log; do mkdir -p $r; done
 for r in infrastructure upload-service; do git clone git@github.com:PermanentOrg/$r.git; done
 ```
 
@@ -66,7 +66,18 @@ source .env && vagrant up
 
 Vagrant will only provision your VM on the first run of `vagrant up`. Every subsequent time, you must pass the `--provision` [flag](https://www.vagrantup.com/docs/cli/up#no-provision) to force a provisioner to run. This may be useful to install changes to the development environment, or wipe stateful data with the `DELETE_DATA` environment variable (see step 4 above). For more information about working with vagrant, check out [the docs](https://www.vagrantup.com/docs).
 
-8. Load the website at https://local.permanent.org/. If you wish to sign up for an account, do that from the form on https://local.permanent.org/app. It's not possible to create an account locally on https://local.permanent.org/login because this form is an iframe pointing to our production instance.
+8. Build the front-end: `npm run build:local`. For performance and
+   compatibility reasons, we do not build the static assets during vagrant
+   provisioning; instead, the Apache instance inside vagrant serves the assets
+   built on the host located in the peer directory `web-app/dist`. See the
+   [web-app](https://github.com/PermanentOrg/web-app) repo for more
+   information.
+
+9. Load the website at https://local.permanent.org/. If you wish to sign up for
+   an account, do that from the form on https://local.permanent.org/app. It's
+   not possible to create an account locally on
+   https://local.permanent.org/login because this form is an iframe pointing to
+   our production instance.
 
 
 ## Troubleshooting

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "../back-end/task-runner", "/data/www/task-runner", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../website", "/data/www/website", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../log", "/var/log/permanent", owner: "vagrant", group: "www-data", mount_options: ["dmode=770", "fmode=660"]
-  config.vm.synced_folder "../web-app", "/data/www/mdot", owner: "vagrant", group: "www-data"
+  config.vm.synced_folder "../web-app/dist", "/data/www/mdot/dist", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../upload-service", "/data/www/upload-service", owner: "vagrant", group: "www-data"
 
   # Provider-specific configuration so you can fine-tune various
@@ -53,7 +53,7 @@ Vagrant.configure(2) do |config|
   #
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--ioapic", "on"]
-    vb.memory = "4096"
+    vb.memory = "2048"
     vb.cpus = 2
     vb.linked_clone = true
   end

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -59,16 +59,6 @@ cd /data/www/library
 rm -rf vendor/
 runuser -l vagrant -c "cd /data/www/library && php bin/composer.phar install --no-plugins"
 
-echo "Configure mdot"
-cd /data/www/mdot
-rm -rf node_modules
-rm -rf bower_components
-runuser -l vagrant -c "cd /data/www/mdot && cp package.json ~ && cp package-lock.json ~"
-runuser -l vagrant -c "cd ~ && npm install --no-bin-links"
-runuser -l vagrant -c "rm package.json package-lock.json && mv node_modules /data/www/mdot/"
-runuser -l vagrant -c "cd /data/www/mdot && npm rebuild node-sass --no-bin-links"
-runuser -l vagrant -c "cd /data/www/mdot && npm run build:local --no-bin-links"
-
 chgrp -R www-data /data/www
 ln -s /data/www/api/tests/files /data/tmp/unittest
 


### PR DESCRIPTION
Building the web-app (formerly mdot) during `vagrant up` causes a lot of problems. The most immediately obvious one is the time it takes; building the web-app is a surprisingly compute- and I/O-heavy process, and both of those resources are diminished inside a virtual machine compared to the host operating system.

The bigger but more subtle problem is that running `vagrant up` breaks the `node_modules` directory on the host: the guest is (almost certainly) a different operating system, and `node_modules` is non-portable because it contains platform-specific code. Worse, we're running `npm install` with the argument `--no-bin-links`, which breaks npm scripts.

After discussion, we decided that we're willing to accept the cost of a slightly more difficult onboarding process for new developers in exchange for a more productive development experience. This commit to stop building mdot/web-app is the first implementation of that decision, as web-app is under more-or-less constant development. We plan not to add the notifications service to vagrant, and we may eventually move the upload service out of vagrant if we find we need to do additional work on it.

Remove the web-app build steps, document the additional manual steps required, and reduce the memory allocation now that we're not building.

Resolves #12 vagrant up breaks host node_modules
