### PR TITLE
Use new name for upload service

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: "sudo service process-daemon restart", run: "always"
   config.vm.provision "shell", inline: "sudo service sqs-daemon restart", run: "always"
   config.vm.provision "shell", inline: "sudo service video-daemon restart", run: "always"
-  config.vm.provision "shell", inline: "sudo service node-upload restart", run: "always"
+  config.vm.provision "shell", inline: "sudo service upload restart", run: "always"
   config.vm.post_up_message = "Finished! App running at https://local.permanent.org/"
 end


### PR DESCRIPTION
We restart each of our services on starting/resuming the Vagrant VM. The service names come from the infrastructure repo. Match the recently renamed upload-service unit from PR https://github.com/PermanentOrg/infrastructure/pull/55.

To test this, either redeploy with https://github.com/PermanentOrg/infrastructure/pull/55 checked out, or modify your local instance:

```sh
sudo service node-upload stop
sudo mv /etc/systemd/system/node-upload.service /etc/systemd/system/upload.service
sudo systemctl daemon-reload
sudo service upload start
```