### PR TITLE
Customizations

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure(2) do |config|
   #
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--ioapic", "on"]
-    vb.memory = "2048"
+    vb.memory = "1024"
     vb.cpus = 2
     vb.linked_clone = true
   end

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,6 +29,8 @@ fi
 
 echo "Install mysql server and memcache"
 apt-get -qq install -y mysql-server memcached
+echo 'bind "^U" vi-kill-line-prev' >> ~root/.editrc
+echo 'bind "^W" ed-delete-prev-word' >> ~root/.editrc
 
 echo "Configure apache"
 runuser -l vagrant -c "aws s3 cp --recursive s3://permanent-local/certs /tmp/certs"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -8,6 +8,9 @@ echo "Install essential software pacakges"
 apt-get -qq update
 apt-get -qq install -y git openssl libssl-dev
 
+echo "Install developer packages"
+apt-get -qq install -y byobu
+
 echo "Configure AWS SQS access"
 
 if [[ "$SQS_IDENT" != _* ]]


### PR DESCRIPTION
I've been running our Vagrant VM with some modifications for a while, and I'd like to get them merged so that I can stop managing them locally.

First, further reduce the memory allocated to the VM, down to 1GB; this makes the VM a bit lighter weight and easier to run alongside more demanding applications on the host.

Second, install [Byobu](https://www.byobu.org/); it does not default to being enabled, so this should not affect anyone else - it just makes it easier for me to opt into using it, by letting me skip the install step.

Finally, fix an [issue](https://bugs.mysql.com/bug.php?id=68449) with the `mysql` text UI by creating a configuration file for root, so that I can hit `ctrl-w` in `sudo mysql` and not lose all my work.