### PR TITLE
Mount back-end repo in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,7 @@ Vagrant.configure(2) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   config.vm.synced_folder "../back-end/api", "/data/www/api", owner: "vagrant", group: "www-data"
+  config.vm.synced_folder "../back-end", "/data/www/back-end", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../docker", "/data/www/docker", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../back-end/daemon", "/data/www/daemon", owner: "vagrant", group: "www-data"
   config.vm.synced_folder "../back-end/library", "/data/www/library", owner: "vagrant", group: "www-data"


### PR DESCRIPTION
When we consolidated api, daemon, library, and task-runner into a single back-end repository, we continued to emulate the old layout by mounting the subdirectories of back-end into their original locations in `/data`. We did the same when packaging, so that we did not have to reconfigure Apache.

In order to allow us to use other subdirectories in back-end, and to support migrating from the disparate directories to the consolidated directory in local/dev/staging/prod, mount back-end directly.

Once the AMIs and Vagrant are in alignment, we can update Apache to use this new directory, but that work must be done later; this just sets the stage.

More immediately, this allows developers to run PHPLint from within Vagrant (instead of only on the host), and will enable us to add more such tools.

---

To test this, you'll need to restart your vagrant VM (eg, `sudo shutdown -h now` from within, and `vagrant up` from the host); a suspend/resume cycle is not enough. You do *not* need to rebuild your VM.