### PR TITLE
Install PHP linting tooling

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -65,6 +65,10 @@ runuser -l vagrant -c "cd /data/www/library && php bin/composer.phar install --n
 chgrp -R www-data /data/www
 ln -s /data/www/api/tests/files /data/tmp/unittest
 
+echo "Configure PHP linting"
+runuser -l vagrant -c "cd /data/www/back-end && php library/bin/composer.phar install --prefer-dist --working-dir=tools/phplint"
+runuser -l vagrant -c "cd /data/www/back-end && php library/bin/composer.phar install --prefer-dist --working-dir=tools/php-cs-fixer"
+
 echo "Configure services and cronjobs"
 
 ln -s --force /data/www/daemon/scripts/queue-daemon.service /etc/systemd/system/


### PR DESCRIPTION
This PR installs the tooling for PHP linting as part of provisioning.

In order to actually run the linters you would:

```
cd /data/www/back-end
./tools/phplint/vendor/bin/phplint
./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run -v
```

This is also documented in the `back-end/README.md`

Resolves #38