### PR TITLE
Don't symlink test files

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -63,7 +63,7 @@ rm -rf vendor/
 runuser -l vagrant -c "cd /data/www/library && php bin/composer.phar install --no-plugins"
 
 chgrp -R www-data /data/www
-ln -s /data/www/api/tests/files /data/tmp/unittest
+mkdir /data/tmp/unittest
 
 echo "Configure PHP linting"
 runuser -l vagrant -c "cd /data/www/back-end && php library/bin/composer.phar install --prefer-dist --working-dir=tools/phplint"


### PR DESCRIPTION
This PR prevents a situation where running local tests would modify the test files.

Our unit tests already copy needed files from `/data/www/api/tests/files` into `/data/tmp/unittest`.

Once this is merged we will all need to run the following in local:

```
rm /data/tmp/unittest
mkdir /data/tmp/unittest
```

You can also test this change locally by running the above command in your environment and then running the unit tests; you should see successful tests AND not see any git changes when you run `git status` in your back-end repository.