### PR TITLE
Fix permission denied complaints in unit tests

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -64,6 +64,7 @@ runuser -l vagrant -c "cd /data/www/library && php bin/composer.phar install --n
 
 chgrp -R www-data /data/www
 mkdir /data/tmp/unittest
+chmod -R 777 /data/tmp/unittest
 
 echo "Configure PHP linting"
 runuser -l vagrant -c "cd /data/www/back-end && php library/bin/composer.phar install --prefer-dist --working-dir=tools/phplint"


### PR DESCRIPTION
Currently, the `back-end` unit tests don't have permission to write to
the vagrant box's `/data/tmp/unittest` directory.
This has been causing warnings, and recently caused my tests to fail
outright, so it must be corrected.
This commit solves the problem by allowing any user on the machine to
write to `/data/tmp/unittest` directory.