### PR TITLE
Grant default user access to system logs

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -41,6 +41,8 @@ a2enmod proxy_http
 a2enmod ssl
 service apache2 start
 
+echo "Grant default user access to system logs"
+adduser vagrant adm
 
 if $DELETE_DATA
 then


### PR DESCRIPTION
Debian provides a system group, `adm`, that has access to read most of `/var/log`. Putting the default vagrant user in that group allows reading those logs without `sudo`.