### PR TITLE
Point to correct postgres schema

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -56,7 +56,7 @@ then
     sudo -u postgres psql -c "CREATE ROLE vagrant WITH LOGIN SUPERUSER PASSWORD 'localdb'";
     sudo -u postgres createuser www-data
     sudo -u postgres createdb --owner=www-data permanent
-    sudo -u postgres psql -d permanent -f /data/www/library/postgres-base.sql
+    sudo -u postgres psql -d permanent -f /data/www/library/postgresql/base.sql
 fi
 
 echo "Configure upload service"


### PR DESCRIPTION
Looking at the back-end repo there is not such file specified by the path `/data/www/library/postgres-base.sql` rather we have `/data/www/library/postgresql/base.sql` and so this commits correct the deploy script to point to that instead.

Signed-off-by: Fon E. Noel NFEBE <fenn25.fn@gmail.com>