### PR TITLE
Incorporate stela into the local environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 export AWS_ACCESS_KEY_ID="tHiSiSyOuRAcCeSsKeY"
 export AWS_ACCESS_SECRET="tHiSiSyOuRAcCeSsSeCrEt"
+export AWS_SECRET_ACCESS_KEY="tHiSiSyOuRAcCeSsSeCrEt - yEsThEsAmEoNeAsAbOvE"
 export AWS_REGION=us-west-2
 export SQS_IDENT=_YourName
 export DELETE_DATA=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 .env
 *.log
+certs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.7"
+services:
+  load_balancer:
+    image: nginx:alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/ssl:ro
+    ports:
+      - "443:443"
+    depends_on:
+      stela:
+        condition: service_healthy
+  stela:
+    restart: always
+    build:
+      context: ../stela
+      dockerfile: Dockerfile.dev
+    ports:
+      - 8080:8080
+    env_file: 
+      - ../stela/.env
+    volumes:
+      - ../stela:/usr/local/apps/stela/dev
+      - ignore:/usr/local/apps/stela/dev/node_modules
+    depends_on:
+      database:
+        condition: service_healthy
+    healthcheck:
+      test: curl http://localhost:8080/api/v2/health
+  database:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: permanent
+    healthcheck:
+      test: pg_isready
+    ports:
+      - "5432:5432"
+  database_setup:
+    image: postgres:14
+    volumes:
+      - ../stela/database/base.sql:/base.sql:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "SELECT 'CREATE DATABASE permanent' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'permanent')\gexec" | psql postgresql://postgres:permanent@database:5432
+        psql postgresql://postgres:permanent@database:5432/permanent -f /base.sql
+    depends_on:
+      database:
+        condition: service_healthy
+volumes:
+  ignore:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,37 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    server {
+      listen 443 ssl;
+      ssl_certificate /etc/ssl/STAR_permanent_org.crt;
+      ssl_certificate_key /etc/ssl/permanent.key;
+      location / {
+        proxy_pass https://192.168.33.10:443;
+      }
+      location /api/v2/ {
+        proxy_pass http://stela:8080;
+      }
+    }
+}


### PR DESCRIPTION
Before we start writing production code in stela, we need it to be part of our local development environment. This commit adds a docker-compose file which brings up stela, a postgres database to be shared by stela and back-end, and an nginx server to properly route requests to either back-end or stela.

Related PRs:
- https://github.com/PermanentOrg/back-end/pull/350
- https://github.com/PermanentOrg/stela/pull/3