### PR TITLE
Run migrations with dbmate

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,4 @@ export AWS_REGION=us-west-2
 export SQS_IDENT=_YourName
 export DELETE_DATA=true
 export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"
+export DATABASE_URL="postgres://vagrant:localdb@127.0.0.1:5432/permanent?sslmode=disable"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,14 +65,18 @@ Vagrant.configure(2) do |config|
     env: {"AWS_ACCESS_KEY_ID": ENV["AWS_ACCESS_KEY_ID"],
           "AWS_ACCESS_SECRET": ENV["AWS_ACCESS_SECRET"],
           "AWS_REGION": ENV["AWS_REGION"],
-          "UPLOAD_SERVICE_SENTRY_DSN": ENV["UPLOAD_SERVICE_SENTRY_DSN"],
+          "APP_USER": "vagrant",
+          "DATABASE_URL": ENV["DATABASE_URL"],
           "PERM_ENV": "local",
           "PERM_SUBDOMAIN": "local",
-          "APP_USER": "vagrant",
-          "TEMPLATES_PATH": "/tmp/templates"}
+          "TEMPLATES_PATH": "/tmp/templates",
+          "UPLOAD_SERVICE_SENTRY_DSN": ENV["UPLOAD_SERVICE_SENTRY_DSN"]
+         }
   config.vm.provision "shell", path: "bin/deploy.sh",
-    env: {"SQS_IDENT": ENV["SQS_IDENT"],
-          "DELETE_DATA": ENV["DELETE_DATA"]}
+    env: {"DATABASE_URL": ENV["DATABASE_URL"],
+          "DELETE_DATA": ENV["DELETE_DATA"],
+          "SQS_IDENT": ENV["SQS_IDENT"]
+          }
   config.vm.provision "shell", inline: "sudo systemctl daemon-reload", run: "always"
   config.vm.provision "shell", inline: "sudo service apache2 restart", run: "always"
   config.vm.provision "shell", inline: "sudo service mysql restart", run: "always"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -103,8 +103,15 @@ ln -s --force /data/www/task-runner/scripts/minute/* /etc/cron.minute/
 
 echo -e "* * * * *\troot\tcd / && run-parts --report /etc/cron.minute" >> /etc/crontab
 
+if [ -z "$DATABASE_URL"]
+then
+    echo "ERROR! Missing environment variable: DATABASE_URL"
+    exit 1
+fi
+
 echo "Run database migrations"
-runuser -l vagrant -c "cd /data/www/library && php migrate.php"
+cd /data/www/back-end/library
+dbmate up
 
 echo "**********************************************************"
 echo "**********************************************************"


### PR DESCRIPTION
You should be able to check this by running `vagrant halt` and then `vagrant up --provision` -- no need to destroy your VM entirely (though note you'll see a lot of errors when you try to reprovision an existing box, mostly around "this database table already exists").

To test this, add a migration in `back-end/library` and reprovision. You can create one as documented by dbmate or use the [example](https://github.com/PermanentOrg/back-end/commit/9162cd56a5e82ba5f78e0227ed75244933cc99b0) I pushed to the back-end repo. Let me know if you'd rather I opened a PR with a comment-only example.

I alphabetized the environment variables in the Vagrantfile. It would be better to save the connection string in .env, probably - is that worth doing?

This requires https://github.com/PermanentOrg/infrastructure/pull/111 to install dbmate.