### PR TITLE
Remove databases from Vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,6 @@ Vagrant.configure(2) do |config|
           }
   config.vm.provision "shell", inline: "sudo systemctl daemon-reload", run: "always"
   config.vm.provision "shell", inline: "sudo service apache2 restart", run: "always"
-  config.vm.provision "shell", inline: "sudo service mysql restart", run: "always"
   config.vm.provision "shell", inline: "sudo service queue-daemon restart", run: "always"
   config.vm.provision "shell", inline: "sudo service process-daemon restart", run: "always"
   config.vm.provision "shell", inline: "sudo service sqs-daemon restart", run: "always"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,9 +10,7 @@ apt-get -qq install -y \
   byobu \
   git \
   libssl-dev \
-  mysql-server \
-  openssl \
-  postgresql-14
+  openssl
 
 echo "Configure AWS SQS access"
 
@@ -23,7 +21,6 @@ if [[ "$SQS_IDENT" != _* ]]
 fi
 
 echo $SQS_IDENT > /data/www/sqs.txt
-echo "mysql" > /data/www/dbchoice.txt
 
 if $DELETE_DATA
 then
@@ -45,18 +42,6 @@ service apache2 start
 
 echo "Grant default user access to system logs"
 adduser vagrant adm
-
-if $DELETE_DATA
-then
-    echo "Populate MySQL"
-    service mysql restart
-    sudo mysql < /data/www/library/base.sql
-
-    sudo -u postgres psql -c "CREATE ROLE vagrant WITH LOGIN SUPERUSER PASSWORD 'localdb'";
-    sudo -u postgres createuser www-data
-    sudo -u postgres createdb --owner=www-data permanent
-    sudo -u postgres psql -d permanent -f /data/www/library/postgresql/base.sql
-fi
 
 echo "Configure upload service"
 cd /data/www/upload-service


### PR DESCRIPTION
Currently, our Vagrant VM runs a MySQL database and a PostgreSQL database. We don't need the MySQL one anymore because we're not using MySQL at all anymore, and we don't need the PostgreSQL one anymore because local instances of our application now use a dockerized PostgreSQL database. In light of this, this commit removes both databases from the Vagrant VM.