### PR TITLE
Add line to AWS CLI install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ sudo apt install virtualbox
 
 and [Docker](https://docs.docker.com/engine/install/ubuntu/).
 
+As well as the [AWS CLI.](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html)
+
 2. Install [Virtualbox Guest Additions](https://www.virtualbox.org/manual/ch04.html) to support mounting shared folders.
 
 ```


### PR DESCRIPTION
This is just a basic README change.

When destroying and rebuilding my devenv, I was confused when I got to downloading the SSL certs since I didn't have `aws` installed. This links to AWS CLI installation instructions for various operating systems.