### PR TITLE
Move local memcached instance to Docker

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,7 +10,6 @@ apt-get -qq install -y \
   byobu \
   git \
   libssl-dev \
-  memcached \
   mysql-server \
   openssl \
   postgresql-14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl http://localhost:8080/api/v2/health
+  cache:
+    image: memcached:1.5.6-alpine
+    ports:
+      - "11211:11211"
   database:
     image: postgres:14
     environment:


### PR DESCRIPTION
Currently we run the memcached instance our local back-end relies on on a Vagrant VM. We want to move away from Vagrant, so this commit moves that memcached instance to a docker container.