### PR TITLE
Update .env.template's local DB connection string

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,4 +5,4 @@ export AWS_REGION=us-west-2
 export SQS_IDENT=_YourName
 export DELETE_DATA=true
 export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"
-export DATABASE_URL="postgres://vagrant:localdb@127.0.0.1:5432/permanent?sslmode=disable"
+export DATABASE_URL="postgres://postgres:permanent@10.0.2.2:5432/permanent?sslmode=disable"

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -102,7 +102,7 @@ ln -s --force /data/www/task-runner/scripts/minute/* /etc/cron.minute/
 
 echo -e "* * * * *\troot\tcd / && run-parts --report /etc/cron.minute" >> /etc/crontab
 
-if [ -z "$DATABASE_URL"]
+if [ -z "$DATABASE_URL" ]
 then
     echo "ERROR! Missing environment variable: DATABASE_URL"
     exit 1


### PR DESCRIPTION
The current value of DATABASE_URL in .env.template assumes the database is running on the Vagrant box. This is no longer in the case in our local dev setup, so this commit updates that value to one that will work with the current dockerized database.