### PR TITLE
Allow HTTP connections in the local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ The repo sync script essentially helps you stay up to date with work going on ac
 
 ## Troubleshooting
 
+- If running `docker compose up` results in an error due to port 80 being in use already, you likely need to turn off
+apache, which runs by default on many distros.
+
 - `local.permanent.org/app` redirects the way we're used to, except that `local.permanent.org` gets replaced with the IP
 where the web app is running in the URL. You'll have to change this back to `local.permanent.org` or things won't work
 properly. `local.permanent.org/app/` avoids this. If you are getting a CORS error, then the above redirection could have 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./certs:/etc/ssl:ro
     ports:
       - "443:443"
+      - "80:80"
     depends_on:
       stela:
         condition: service_healthy
@@ -16,7 +17,7 @@ services:
       context: ../stela
       dockerfile: Dockerfile.dev
     ports:
-      - 8080:8080
+      - "8080:8080"
     env_file:
       - ../stela/.env
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,7 @@ http {
     keepalive_timeout  65;
 
     server {
+      listen *:80;
       listen 443 ssl;
       ssl_certificate /etc/ssl/STAR_permanent_org.crt;
       ssl_certificate_key /etc/ssl/permanent.key;


### PR DESCRIPTION
Presently, the nginx instance that routes requests to either back-end or stela in the local environment only supports https. Because it would take some effort to set up stela to be able to make https calls in the local environment, and because this effort wouldn't have any meaningful benefit, it is preferable to allow http calls. This commit updates the docker compose and nginx.conf to do this.