### PR TITLE
Use a writable volume for base.sql in database_setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   database_setup:
     image: postgres:14-alpine
     volumes:
-      - ../stela/database/base.sql:/base.sql:ro
+      - ../stela/database/base.sql:/base.sql
       - ../back-end/library/db:/db:ro
     entrypoint: ["/bin/sh", "-c"]
     command:


### PR DESCRIPTION
We're seeing strange behavior in back-end CI where database_setup appears to use an outdated version of base.sql rather than picking up the one in the stela directory. We think maybe a writeable volume will fix this.