### PR TITLE
Revert "Use a writable volume for base.sql in database_setup"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   database_setup:
     image: postgres:14-alpine
     volumes:
-      - ../stela/database/base.sql:/base.sql
+      - ../stela/database/base.sql:/base.sql:ro
       - ../back-end/library/db:/db:ro
     entrypoint: ["/bin/sh", "-c"]
     command:


### PR DESCRIPTION
Reverts PermanentOrg/devenv#65 Reverting because it didn't solve our problem, and it makes more sense for this to be a read only volume