### PR TITLE
Update docker-compose to reflect stela updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
     env_file:
       - ../stela/.env
     volumes:
-      - ../stela:/usr/local/apps/stela/dev
-      - ignore:/usr/local/apps/stela/dev/node_modules
+      - ../stela:/usr/local/apps/stela/
+      - ignore:/usr/local/apps/stela/node_modules
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
Removing ts-node from stela involved changing how it does hot-loading in the local environment. One effect of this is that it no longer uses the /dev directory; this commit updates docker-compose.yml to reflect that.