### PR TITLE
Upgrade vagrant box to Debian 11

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "generic/debian10"
+  config.vm.box = "generic/debian11"
   config.vm.box_version = "3.4.0"
   config.vm.define "permanent"
 


### PR DESCRIPTION
Debian 10 will exit long term support this year, so we are upgrading our infrastructure to Debian 11. The local environment should match the deployed environments as much as practicable, so this commit updates the vagrant box to Debian 11 as well.