### PR TITLE
Per 9743 replace vagrant with docker

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,5 @@ export SQS_IDENT=_YourName
 export DELETE_DATA=true
 export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"
 export DATABASE_URL="postgres://postgres:permanent@10.0.2.2:5432/permanent?sslmode=disable"
+export NOTIFICATION_DATABASE_URL="postgresql://user:password@host/db_name"
+export NOTIFICATION_FIREBASE_CREDENTIALS='{"format":"minified JSON";"see":"https://github.com/PermanentOrg/notification-service/"}'

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ We use the latest Debian build published [here](https://app.vagrantup.com/generi
 
 1. Prerequisites
 
+   - Access to AWS
+   - Install [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html)
    - Install [Docker](https://docs.docker.com/get-docker/)
    - Install npm and node (most packages require node 18)
-   - Access to AWS
    - Access to Fusionauth OR the values of the env variables that need to be set up for Fusionauth to work.
    - Access to repositories `back-end`, `infrastructure`, `notification-service`, `upload-service`, `web-app`, `stela`
 
@@ -43,8 +44,7 @@ We use the latest Debian build published [here](https://app.vagrantup.com/generi
    ```
 
 1. `cp .env.template .env` and define the required environment variables in `.env` using your preferred file editor.
-   You will need to do this for both this repo and the `stela` and `web-app` repos, as they both have the `.env` file referenced in
-   the docker compose file.
+   You will need to do this for both this repo and the `stela` and `web-app` repos, as they both have the `.env` file referenced in the docker compose file.
 
    - Create an AWS Access Key [here](https://console.aws.amazon.com/iam/home?#/security_credentials) and download the credentials.
    - Add values for the following variables associated with the key: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_ACCESS_SECRET`.
@@ -52,18 +52,18 @@ We use the latest Debian build published [here](https://app.vagrantup.com/generi
    - `UPLOAD_SERVICE_SENTRY_DSN` is optional and allows sentry configuration for the upload service.
    - `NOTIFICATION_DATABASE_URL` and `NOTIFICATION_FIREBASE_CREDENTIALS` are required for the notification service
 
+1. Download the SSL certs for the nginx load balancer to use inside the docker network.
+   It's important that the AWS env vars have been set for the CLI command to work
+
+   ```
+   source .env && aws s3 cp --recursive s3://permanent-local/certs ./certs
+   ```
+
 1. Edit your local host file (e.g. `/etc/hosts`) to connect to the host with the correct domain name.
 
    ```bash
    printf "\n127.0.0.1 local.permanent.org" | sudo tee -a /etc/hosts
    ```
-
-<!-- 1. Build `stela`
-
-   ```
-   cd ../stela
-   npm run build -ws
-   ``` -->
 
 1. Return to `devenv` and run the following command to bring a development environment for the first
    time, or to start up a halted VMs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,10 +63,10 @@ services:
     env_file:
       - ../stela/.env
     volumes:
-      - ../stela:/usr/local/apps/stela/
-      - ignore_module:/usr/local/apps/stela/node_modules
-      - ignore_api:/usr/local/apps/stela/packages/api/node_modules
-      - ignore_logger:/usr/local/apps/stela/packages/logger/node_modules
+      - ../stela/packages/api/src:/usr/local/apps/stela/packages/api/src
+      - ../stela/packages/logger/src:/usr/local/apps/stela/packages/logger/src
+      - ../stela/packages/archivematica_cleanup/src:/usr/local/apps/stela/packages/archivematica_cleanup/src
+      - ../stela/packages/account_space_updater/src:/usr/local/apps/stela/packages/account_space_updater/src
     depends_on:
       database:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   back-end:
     build:
       context: ../
-      dockerfile: back-end/Dockerfile.dev3
+      dockerfile: back-end/Dockerfile.dev
       args:
         # these args are available because of the .env file located next to the docker-compose.yml file
         # which is automatically incorporated by docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,8 @@ services:
       dockerfile: web-app/Dockerfile.local
     command: npm run dev:docker
     image: web-app
-    depends_on:
-      database:
-        condition: service_healthy
+    volumes:
+      - ../web-app/src:/usr/app/src:ro
   back-end:
     build:
       context: ../
@@ -45,7 +44,6 @@ services:
     volumes:
       - ../back-end/api:/data/www/api
       - ../log:/var/log/permanent
-      # - ../back-end/library:/data/www/library
     depends_on:
       database:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,8 @@ services:
   web-app:
     build:
       context: ../
-      dockerfile: web-app/Dockerfile.dev
-      args:
-        # these args are available because of the .env file located next to the docker-compose.yml file
-        # which is automatically incorporated by docker
-        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-        AWS_ACCESS_SECRET: ${AWS_ACCESS_SECRET}
-        AWS_REGION: ${AWS_REGION}
+      dockerfile: web-app/Dockerfile.local
+    command: npm run dev:docker
     image: web-app
     depends_on:
       database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
     build:
       context: ../
       dockerfile: back-end/Dockerfile.dev3
-      # TODO -> see if args are needed
       args:
         # these args are available because of the .env file located next to the docker-compose.yml file
         # which is automatically incorporated by docker
@@ -41,12 +40,17 @@ services:
         AWS_ACCESS_SECRET: ${AWS_ACCESS_SECRET}
         AWS_REGION: ${AWS_REGION}
         SQS_IDENT: ${SQS_IDENT}
+        UPLOAD_SERVICE_SENTRY_DSN: ${UPLOAD_SERVICE_SENTRY_DSN}
+        NOTIFICATION_DATABASE_URL: ${NOTIFICATION_DATABASE_URL}
+        NOTIFICATION_FIREBASE_CREDENTIALS: ${NOTIFICATION_FIREBASE_CREDENTIALS}
     image: back-end
     env_file:
-      # env file path seems relative to docker-compose file
+      # env file path is relative to docker-compose file
+      # Availability of env vars at build and during run requires separate configs.
       - ./.env
     volumes:
       - ../back-end/api:/data/www/api
+      - ../log:/var/log/permanent
       # - ../back-end/library:/data/www/library
     depends_on:
       database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       stela:
         condition: service_healthy
       web-app:
-        # TODO -> update condition to healty
         condition: service_started
   web-app:
     build:
@@ -43,6 +42,7 @@ services:
       - ./.env
     volumes:
       - ../back-end/api:/data/www/api
+      - ../back-end/daemon:/data/www/daemon
       - ../log:/var/log/permanent
     depends_on:
       database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   load_balancer:
     image: nginx:alpine
@@ -11,6 +10,53 @@ services:
     depends_on:
       stela:
         condition: service_healthy
+      web-app:
+        # TODO -> update condition to healty
+        condition: service_started
+  web-app:
+    build:
+      context: ../
+      dockerfile: web-app/Dockerfile.dev
+      args:
+        # these args are available because of the .env file located next to the docker-compose.yml file
+        # which is automatically incorporated by docker
+        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+        AWS_ACCESS_SECRET: ${AWS_ACCESS_SECRET}
+        AWS_REGION: ${AWS_REGION}
+    image: web-app
+    depends_on:
+      database:
+        condition: service_healthy
+  back-end:
+    build:
+      context: ../
+      dockerfile: back-end/Dockerfile.dev3
+      # TODO -> see if args are needed
+      args:
+        # these args are available because of the .env file located next to the docker-compose.yml file
+        # which is automatically incorporated by docker
+        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+        AWS_ACCESS_SECRET: ${AWS_ACCESS_SECRET}
+        AWS_REGION: ${AWS_REGION}
+        SQS_IDENT: ${SQS_IDENT}
+    image: back-end
+    env_file:
+      # env file path seems relative to docker-compose file
+      - ./.env
+    volumes:
+      - ../back-end/api:/data/www/api
+      # - ../back-end/library:/data/www/library
+    depends_on:
+      database:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+        reservations:
+          cpus: "1.0"
   stela:
     restart: always
     build:
@@ -40,7 +86,10 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: permanent
     healthcheck:
-      test: pg_isready
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U postgres -d permanent'"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
     ports:
       - "5432:5432"
   database_setup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     command: npm run dev:docker
     image: web-app
     volumes:
-      - ../web-app/src:/usr/app/src:ro
+      - ../web-app/src:/usr/app/src:rw
   back-end:
     build:
       context: ../

--- a/docker/apache/LICENSE
+++ b/docker/apache/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2014 Docker, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docker/apache/apache2-foreground
+++ b/docker/apache/apache2-foreground
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# Note: we don't just use "apache2ctl" here because it itself is just a shell-script wrapper around apache2 which provides extra functionality like "apache2ctl start" for launching apache2 in the background.
+# (also, when run as "apache2ctl <apache args>", it does not use "exec", which leaves an undesirable resident shell process)
+
+: "${APACHE_CONFDIR:=/etc/apache2}"
+: "${APACHE_ENVVARS:=$APACHE_CONFDIR/envvars}"
+if test -f "$APACHE_ENVVARS"; then
+	. "$APACHE_ENVVARS"
+fi
+
+# Apache gets grumpy about PID files pre-existing
+: "${APACHE_RUN_DIR:=/var/run/apache2}"
+: "${APACHE_PID_FILE:=$APACHE_RUN_DIR/apache2.pid}"
+rm -f "$APACHE_PID_FILE"
+
+# create missing directories
+# (especially APACHE_RUN_DIR, APACHE_LOCK_DIR, and APACHE_LOG_DIR)
+for e in "${!APACHE_@}"; do
+	if [[ "$e" == *_DIR ]] && [[ "${!e}" == /* ]]; then
+		# handle "/var/lock" being a symlink to "/run/lock", but "/run/lock" not existing beforehand, so "/var/lock/something" fails to mkdir
+		#   mkdir: cannot create directory '/var/lock': File exists
+		dir="${!e}"
+		while [ "$dir" != "$(dirname "$dir")" ]; do
+			dir="$(dirname "$dir")"
+			if [ -d "$dir" ]; then
+				break
+			fi
+			absDir="$(readlink -f "$dir" 2>/dev/null || :)"
+			if [ -n "$absDir" ]; then
+				mkdir -p "$absDir"
+			fi
+		done
+
+		mkdir -p "${!e}"
+	fi
+done
+
+echo "[valle] Found these: $@"
+
+exec apache2 -DFOREGROUND "$@"

--- a/docker/apache/docker-php-entrypoint
+++ b/docker/apache/docker-php-entrypoint
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- apache2-foreground "$@"
+fi
+
+exec "$@"

--- a/docker/apache/docker-php-ext-configure
+++ b/docker/apache/docker-php-ext-configure
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -e
+
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
+usage() {
+	echo "usage: $0 ext-name [configure flags]"
+	echo "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
+	echo
+	echo 'Possible values for ext-name:'
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
+	echo
+	echo 'Some of the above modules are already compiled into PHP; please check'
+	echo 'the output of "php -i" to see which modules are already loaded.'
+}
+
+ext="$1"
+if [ -z "$ext" ] || [ ! -d "$ext" ]; then
+	usage >&2
+	exit 1
+fi
+shift
+
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+	fi
+fi
+
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
+cd "$ext"
+phpize
+./configure --enable-option-checking=fatal "$@"

--- a/docker/apache/docker-php-ext-enable
+++ b/docker/apache/docker-php-ext-enable
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -e
+
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
+cd "$extDir"
+
+usage() {
+	echo "usage: $0 [options] module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --ini-name 0-apc.ini apcu apc"
+	echo
+	echo 'Possible values for module-name:'
+	find -maxdepth 1 \
+		-type f \
+		-name '*.so' \
+		-exec basename '{}' ';' |
+		sort |
+		xargs
+	echo
+	echo 'Some of the above modules are already compiled into PHP; please check'
+	echo 'the output of "php -i" to see which modules are already loaded.'
+}
+
+opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+iniName=
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+	--help | -h | '-?') usage && exit 0 ;;
+	--ini-name) iniName="$1" && shift ;;
+	--) break ;;
+	*)
+		{
+			echo "error: unknown flag: $flag"
+			usage
+		} >&2
+		exit 1
+		;;
+	esac
+done
+
+modules=
+for module; do
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
+		echo >&2 "error: '$module' does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules="$modules $module"
+done
+
+if [ -z "$modules" ]; then
+	usage >&2
+	exit 1
+fi
+
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if
+		[ -n "$PHPIZE_DEPS" ] &&
+			! apk info --installed .phpize-deps >/dev/null &&
+			! apk info --installed .phpize-deps-configure >/dev/null \
+			;
+	then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
+for module in $modules; do
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	case "$iniName" in
+	/*)
+		# allow an absolute path
+		ini="$iniName"
+		;;
+	*)
+		ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
+		;;
+	esac
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+		echo "$line" >>"$ini"
+	fi
+done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del --no-network $apkDel
+fi

--- a/docker/apache/docker-php-ext-install
+++ b/docker/apache/docker-php-ext-install
@@ -1,0 +1,143 @@
+#!/bin/sh
+set -e
+
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
+usage() {
+	echo "usage: $0 [-jN] [--ini-name file.ini] ext-name [ext-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo "       $0 -j5 gd mbstring mysqli pdo pdo_mysql shmop"
+	echo
+	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
+	echo
+	echo 'Possible values for ext-name:'
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
+	echo
+	echo 'Some of the above modules are already compiled into PHP; please check'
+	echo 'the output of "php -i" to see which modules are already loaded.'
+}
+
+opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+j=1
+iniName=
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+		--help|-h|'-?') usage && exit 0 ;;
+		--ini-name) iniName="$1" && shift ;;
+		--jobs|-j) j="$1" && shift ;;
+		--) break ;;
+		*)
+			{
+				echo "error: unknown flag: $flag"
+				usage
+			} >&2
+			exit 1
+			;;
+	esac
+done
+
+exts=
+for ext; do
+	if [ -z "$ext" ]; then
+		continue
+	fi
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	exts="$exts $ext"
+done
+
+if [ -z "$exts" ]; then
+	usage >&2
+	exit 1
+fi
+
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if [ -n "$PHPIZE_DEPS" ]; then
+		if apk info --installed .phpize-deps-configure > /dev/null; then
+			apkDel='.phpize-deps-configure'
+		elif ! apk info --installed .phpize-deps > /dev/null; then
+			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apkDel='.phpize-deps'
+		fi
+	fi
+fi
+
+popDir="$PWD"
+for ext in $exts; do
+	cd "$ext"
+
+	[ -e Makefile ] || docker-php-ext-configure "$ext"
+
+	make -j"$j"
+
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
+		# only "strip" modules if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+
+		find modules \
+			-maxdepth 1 \
+			-name '*.so' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || :
+			' -- '{}' +
+	fi
+
+	make -j"$j" install
+
+	find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-exec basename '{}' ';' \
+			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+
+	make -j"$j" clean
+
+	cd "$popDir"
+done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del --no-network $apkDel
+fi
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/docker/apache/docker-php-source
+++ b/docker/apache/docker-php-source
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e
+
+dir=/usr/src/php
+
+usage() {
+	echo "usage: $0 COMMAND"
+	echo
+	echo "Manage php source tarball lifecycle."
+	echo
+	echo "Commands:"
+	echo "   extract  extract php source tarball into directory $dir if not already done."
+	echo "   delete   delete extracted php source located into $dir if not already done."
+	echo
+}
+
+case "$1" in
+	extract)
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
+			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
+			touch "$dir/.docker-extracted"
+		fi
+		;;
+
+	delete)
+		rm -rf "$dir"
+		;;
+
+	*)
+		usage
+		exit 1
+		;;
+esac

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,7 +35,7 @@ http {
         proxy_pass https://back-end:443;
       }
       location / {
-        proxy_pass https://web-app:443;
+        proxy_pass https://web-app:4200;
       }
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,6 @@ events {
     worker_connections  1024;
 }
 
-
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
@@ -28,11 +27,15 @@ http {
       listen 443 ssl;
       ssl_certificate /etc/ssl/STAR_permanent_org.crt;
       ssl_certificate_key /etc/ssl/permanent.key;
-      location / {
-        proxy_pass https://192.168.33.10:443;
-      }
+
       location /api/v2/ {
         proxy_pass http://stela:8080;
+      }
+      location /api {
+        proxy_pass https://back-end:443;
+      }
+      location / {
+        proxy_pass https://web-app:443;
       }
     }
 }

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -1,0 +1,72 @@
+[supervisord]
+logfile = /var/log/permanent/supervisord.log
+logfile_maxbytes = 10MB
+logfile_backups=0
+loglevel = debug
+pidfile = /tmp/supervisord.pid
+nodaemon = false
+user = root
+identifier = supervisor
+nocleanup = true
+childlogdir = /var/log/permanent
+strip_ansi = false
+
+[program:queue-daemon]
+command=php /data/www/daemon/index.php queue
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/permanent/queue-daemon.err.log
+stdout_logfile=/var/log/permanent/queue-daemon.out.log
+user=www-data
+
+[program:process-daemon]
+command=php /data/www/daemon/index.php process
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/permanent/process-daemon.err.log
+stdout_logfile=/var/log/permanent/process-daemon.out.log
+user=www-data
+
+[program:sqs-daemon]
+command=php /data/www/daemon/index.php sqs
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/permanent/sqs-daemon.err.log
+stdout_logfile=/var/log/permanent/sqs-daemon.out.log
+user=www-data
+
+[program:video-daemon]
+command=php /data/www/daemon/index.php video
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/permanent/video-daemon.err.log
+stdout_logfile=/var/log/permanent/video-daemon.out.log
+user=www-data
+
+[program:upload-service]
+directory=/data/www/upload-service
+command=node /data/www/upload-service/lib/index.js
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/permanent/upload-service.err.log
+stdout_logfile=/var/log/permanent/upload-service.out.log
+user=www-data
+environment=AWS_SDK_LOAD_CONFIG="true",NODE_ENV="local",PORT="3000",SENTRY_DSN="${UPLOAD_SERVICE_SENTRY_DSN}",SENTRY_ENVIRONMENT="local"
+
+[program:notification-service]
+directory=/data/www/notification-service
+command=node /data/www/notification-service/lib/index.js
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/permanent/notification-service.err.log
+stdout_logfile=/var/log/permanent/notification-service.out.log
+user=www-data
+environment=NODE_ENV="local",PORT="3001",DATABASE_URL="${NOTIFICATION_DATABASE_URL}"
+
+; [program:cron]
+; command=service cron stop && /usr/sbin/cron -f -l 8
+; autostart=true
+; autorestart=true
+; stderr_logfile=/var/log/permanent/cron.err.log
+; stdout_logfile=/var/log/permanent/cron.out.log
+; user=root


### PR DESCRIPTION
The `docker-compose.yml` file has been modified to include the PHP api as a Docker VM. It also contains the web-app as a separate VM container, as they were previously served together by the Vagrant VM.
For the setup to work, the nginx conf file had to be updated.
Also, the postgres healthcheck config was updated beacuse it was causing an error in the postgres server and was polluting the logs.

Some of the commands that are run in the back-end container are based on the `php:8.3-bookworm` docker image, and this required the presence of certain shell scripts. These have been added in this repo so that they can be included in the image build process. They are subject to the Docker MIT license which is included with the files.

The original Vagrant VM was running multiple processes. Unfortunately Docker does not provide easy access to `systemctl` and the recommended solution is to use a process manager. For this reason **supervisord** was installed and configured.