### PR TITLE
Make the bound psql port configurable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,7 @@ export AWS_REGION=us-west-2
 export SQS_IDENT=_YourName
 export DELETE_DATA=true
 export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"
-export DATABASE_URL="postgres://postgres:permanent@10.0.2.2:5432/permanent?sslmode=disable"
+export DATABASE_URL="postgres://postgres:permanent@database:5432/permanent?sslmode=disable"
+export HOST_DB_PORT=5432
 export NOTIFICATION_DATABASE_URL="postgresql://user:password@host/db_name"
 export NOTIFICATION_FIREBASE_CREDENTIALS='{"format":"minified JSON";"see":"https://github.com/PermanentOrg/notification-service/"}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       timeout: 3s
       retries: 3
     ports:
-      - "5432:5432"
+      - "${HOST_DB_PORT:-5432}:5432"
   database_setup:
     image: postgres:14-alpine
     volumes:


### PR DESCRIPTION
This PR changes our docker-compose so that the psql port bound to host is configurable.  This means developers who run psql on their machine can pick an open port instead.

As part of this change we also update the docker-compose so that back-end is talking directly to the database rather than routing through the host

Resolves #57