### PR TITLE
Fix load balancer brittleness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ name: permanent
 services:
   load_balancer:
     image: nginx:alpine
+    restart: on-failure
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./certs:/etc/ssl:ro
@@ -81,6 +82,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl http://localhost:8080/api/v2/health
+      start_period: 30s
   cache:
     image: memcached:1.5.6-alpine
     ports:


### PR DESCRIPTION
Frequently the load balancer crashes when starting the local environment because stela registers as ready before it can actually receive calls. This commit adds two changes to fix this issue; it makes the stela container wait 30 seconds before broadcasting that it's ready to ensure it's fully started up, and it makes the load balancer attempt to restart if it crashes.