### PR TITLE
Add file copier lambda to the local environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,8 @@ services:
         condition: service_completed_successfully
       metadata_attacher_lambda_builder:
         condition: service_completed_successfully
+      file_copier_lambda_builder:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
       interval: 10s
@@ -212,6 +214,15 @@ services:
       localstack:
         condition: service_healthy
     restart: on-failure
+  file_copier_lambda_builder:
+    build:
+      context: ../stela
+      dockerfile: packages/file_copier/Dockerfile
+    image: file_copier_lambda:latest
+    entrypoint: ["/bin/sh", "-c", "echo 'Lambda image built successfully' && exit 0"]
+    depends_on:
+      database:
+        condition: service_healthy
   sqs-lambda-bridge:
     build:
       context: ./sqs-lambda-bridge

--- a/lambda/sam_template.yaml
+++ b/lambda/sam_template.yaml
@@ -19,6 +19,7 @@ Resources:
           ARCHIVEMATICA_PROCESSING_WORKFLOW: ""
           ENV: ""
           AWS_REGION: ""
+          SENTRY_DSN: ""
     Metadata:
       DockerContext: ../stela
       Dockerfile: Dockerfile.trigger_archivematica
@@ -95,6 +96,27 @@ Resources:
       DockerContext: ../stela
       Dockerfile: Dockerfile.metadata_attacher
 
+  FileCopierFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageUri: file_copier_lambda:latest
+      Timeout: 300
+      MemorySize: 512
+      Environment:
+        Variables:
+          DATABASE_URL: ""
+          ENV: ""
+          AWS_REGION: ""
+          CLOUDFRONT_URL: ""
+          CLOUDFRONT_KEY_PAIR_ID: ""
+          CLOUDFRONT_PRIVATE_KEY: ""
+          S3_BUCKET: ""
+          SENTRY_DSN: ""
+    Metadata:
+      DockerContext: ../stela
+      Dockerfile: packages/file_copier/Dockerfile
+
 Outputs:
   TriggerArchivematicaFunctionName:
     Description: Name of the Trigger Archivematica Lambda function
@@ -126,3 +148,9 @@ Outputs:
   MetadataAttacherFunctionArn:
     Description: ARN of the Metadata Attacher Lambda function
     Value: !GetAtt MetadataAttacherFunction.Arn
+  FileCopierFunctionName:
+    Description: Name of the File Copier Lambda function
+    Value: !Ref FileCopierFunction
+  FileCopierFunctionArn:
+    Description: ARN of the File Copier Lambda function
+    Value: !GetAtt FileCopierFunction.Arn

--- a/lambda/start-sam-local.sh
+++ b/lambda/start-sam-local.sh
@@ -61,11 +61,14 @@ fi
 if ! docker images | grep -q "metadata_attacher_lambda"; then
     MISSING_IMAGES+=("metadata_attacher_lambda")
 fi
+if ! docker images | grep -q "file_copier_lambda"; then
+    MISSING_IMAGES+=("file_copier_lambda")
+fi
 
 if [ ${#MISSING_IMAGES[@]} -gt 0 ]; then
     echo "ERROR: Lambda image(s) not found: ${MISSING_IMAGES[*]}"
     echo "Build them first with:"
-    echo "  docker compose up -d trigger_archivematica_lambda_builder record_thumbnail_attacher_lambda_builder access_copy_attacher_lambda_builder account_space_updater_lambda_builder metadata_attacher_lambda_builder"
+    echo "  docker compose up -d trigger_archivematica_lambda_builder record_thumbnail_attacher_lambda_builder access_copy_attacher_lambda_builder account_space_updater_lambda_builder metadata_attacher_lambda_builder file_copier_lambda_builder"
     exit 1
 fi
 
@@ -95,7 +98,8 @@ cat > "$ENV_VARS_FILE" <<EOF
     "ARCHIVEMATICA_ORIGINAL_LOCATION_ID": "$ARCHIVEMATICA_ORIGINAL_LOCATION_ID",
     "ARCHIVEMATICA_PROCESSING_WORKFLOW": "$ARCHIVEMATICA_PROCESSING_WORKFLOW",
     "ENV": "$ENV",
-    "AWS_REGION": "$AWS_REGION"
+    "AWS_REGION": "$AWS_REGION",
+    "SENTRY_DSN": "$SENTRY_DSN"
   },
   "RecordThumbnailAttacherFunction": {
     "DATABASE_URL": "$DATABASE_URL",
@@ -120,10 +124,20 @@ cat > "$ENV_VARS_FILE" <<EOF
     "ENV": "$ENV",
     "AWS_REGION": "$AWS_REGION"
   },
-  "AccountSpaceUpdaterFunction": {
+  "MetadataAttacherFunction": {
     "DATABASE_URL": "$DATABASE_URL",
     "ENV": "$ENV",
     "AWS_REGION": "$AWS_REGION"
+  },
+  "FileCopierFunction": {
+    "DATABASE_URL": "$DATABASE_URL",
+    "ENV": "$ENV",
+    "AWS_REGION": "$AWS_REGION",
+    "CLOUDFRONT_URL": "$CLOUDFRONT_URL",
+    "CLOUDFRONT_KEY_PAIR_ID": "$CLOUDFRONT_KEY_PAIR_ID",
+    "CLOUDFRONT_PRIVATE_KEY": "$CLOUDFRONT_PRIVATE_KEY",
+    "S3_BUCKET": "$S3_BUCKET",
+    "SENTRY_DSN": "$SENTRY_DSN"
   }
 }
 EOF

--- a/localstack-init/setup_resources.sh
+++ b/localstack-init/setup_resources.sh
@@ -21,6 +21,11 @@ ACCOUNT_SPACE_QUEUE_URL=$(awslocal sqs create-queue --queue-name Local_Account_S
 ACCOUNT_SPACE_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $ACCOUNT_SPACE_QUEUE_URL --attribute-names QueueArn --region $REGION --query 'Attributes.QueueArn' --output text)
 echo "Created queue: $ACCOUNT_SPACE_QUEUE_ARN"
 
+echo "Creating SQS queue: Local_File_Copier_Queue$SQS_IDENT"
+FILE_COPIER_QUEUE_URL=$(awslocal sqs create-queue --queue-name Local_File_Copier_Queue$SQS_IDENT --region $REGION --query 'QueueUrl' --output text)
+FILE_COPIER_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url $FILE_COPIER_QUEUE_URL --attribute-names QueueArn --region $REGION --query 'Attributes.QueueArn' --output text)
+echo "Created queue: $FILE_COPIER_QUEUE_ARN"
+
 echo "Setting up Archivematica SQS queue policy to allow SNS to send messages"
 awslocal sqs set-queue-attributes \
   --queue-url $ARCHIVEMATICA_QUEUE_URL \
@@ -32,6 +37,12 @@ awslocal sqs set-queue-attributes \
   --queue-url $ACCOUNT_SPACE_QUEUE_URL \
   --region $REGION \
   --attributes "{\"Policy\":\"{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":\\\"*\\\",\\\"Action\\\":\\\"sqs:SendMessage\\\",\\\"Resource\\\":\\\"$ACCOUNT_SPACE_QUEUE_ARN\\\",\\\"Condition\\\":{\\\"ArnEquals\\\":{\\\"aws:SourceArn\\\":\\\"$TOPIC_ARN\\\"}}}]}\"}"
+
+echo "Setting up file copier SQS queue policy to allow SNS to send messages"
+awslocal sqs set-queue-attributes \
+  --queue-url $FILE_COPIER_QUEUE_URL \
+  --region $REGION \
+  --attributes "{\"Policy\":\"{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":\\\"*\\\",\\\"Action\\\":\\\"sqs:SendMessage\\\",\\\"Resource\\\":\\\"$FILE_COPIER_QUEUE_ARN\\\",\\\"Condition\\\":{\\\"ArnEquals\\\":{\\\"aws:SourceArn\\\":\\\"$TOPIC_ARN\\\"}}}]}\"}"
 
 echo "Subscribing Archivematica SQS queue to SNS topic with message filtering"
 ARCHIVEMATICA_SUBSCRIPTION_ARN=$(awslocal sns subscribe \
@@ -55,6 +66,17 @@ ACCOUNT_SPACE_SUBSCRIPTION_ARN=$(awslocal sns subscribe \
   --output text)
 echo "Created subscription: $ACCOUNT_SPACE_SUBSCRIPTION_ARN"
 
+echo "Subscribing File Copier SQS queue to SNS topic with message filtering"
+FILE_COPIER_SUBSCRIPTION_ARN=$(awslocal sns subscribe \
+  --topic-arn $TOPIC_ARN \
+  --protocol sqs \
+  --notification-endpoint $FILE_COPIER_QUEUE_ARN \
+  --region $REGION \
+  --attributes "{\"FilterPolicy\":\"{\\\"Entity\\\":[\\\"file\\\"],\\\"Action\\\":[\\\"copy\\\"]}\"}" \
+  --query 'SubscriptionArn' \
+  --output text)
+echo "Created subscription: $FILE_COPIER_SUBSCRIPTION_ARN"
+
 echo "LocalStack resources initialized successfully!"
 echo "Note: Lambda function is managed by SAM Local (not LocalStack)"
 echo "Event processing is handled by the SQS-Lambda bridge service"
@@ -63,3 +85,5 @@ echo "Archivematica Queue ARN: $ARCHIVEMATICA_QUEUE_ARN"
 echo "Archivematica Queue URL: $ARCHIVEMATICA_QUEUE_URL"
 echo "Account Space Queue ARN: $ACCOUNT_SPACE_QUEUE_ARN"
 echo "Account Space Queue URL: $ACCOUNT_SPACE_QUEUE_URL"
+echo "File Copier Queue ARN: $FILE_COPIER_QUEUE_ARN"
+echo "File Copier Queue URL: $FILE_COPIER_QUEUE_URL"

--- a/sqs-lambda-bridge/config.example.json
+++ b/sqs-lambda-bridge/config.example.json
@@ -76,6 +76,22 @@
       "waitTimeSeconds": 20,
       "visibilityTimeout": 300,
       "deleteOnError": false
+    },
+    {
+      "name": "file_copier",
+      "queue": {
+        "queueUrl": "http://localstack:4566/000000000000/Local_File_Copier_Queue_<DevName>",
+        "queueArn": "arn:aws:sqs:us-west-2:000000000000:Local_File_Copier_Queue_<DevName>",
+        "endpoint": "http://localstack:4566"
+      },
+      "lambda": {
+        "functionName": "FileCopierFunction",
+        "endpoint": "http://host.docker.internal:3001"
+      },
+      "batchSize": 10,
+      "waitTimeSeconds": 20,
+      "visibilityTimeout": 300,
+      "deleteOnError": false
     }
   ]
 }


### PR DESCRIPTION
We recently added a lambda to stela to handle the asynchronous parts of record copy. This commit adds it to our local environment.